### PR TITLE
Fixed instantiation error for BackgroundController.

### DIFF
--- a/src/background/index.js
+++ b/src/background/index.js
@@ -1,4 +1,4 @@
 import BackgroundController from './BackgroundController.js';
 
-const backgroundController = BackgroundController();
+const backgroundController = new BackgroundController();
 backgroundController.init();


### PR DESCRIPTION
Looks like the `new` keyword slipped the commit, but remained on my box. It was causing a runtime error in the background script.