### PR TITLE
Making our extension CSP compliant by disallowing unsafe-eval.

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -17,7 +17,7 @@
         "http://*/*",
         "https://*/*"
     ],
-    "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'",
+    "content_security_policy": "script-src 'self'; object-src 'self'",
     "web_accessible_resources": [
         "inject.bundle.js"
     ],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,6 +13,7 @@ module.exports = {
     inject: './src/inject/index.js'
   },
   mode: 'development',
+  devtool: 'source-map',
   module: {
     rules: [
       {


### PR DESCRIPTION
This fixes extension crashes when being loaded on pages that disallow unsafe-eval. A nice side effect is that we now have full source maps during development, which is useful for debugging.

This resolves issue #27.