### PR TITLE
Removed all console.log statements in the code except for the background script

### DIFF
--- a/src/content/index.js
+++ b/src/content/index.js
@@ -6,18 +6,14 @@ import { forwardTimingEvent, sendSimpleMessage } from './messaging';
 import injectScript from './injectScript';
 
 document.addEventListener('MezzuriteFound', () => {
-  console.log('CS: Got an event: MezzuriteFound');
   sendSimpleMessage('mezzuriteFound');
 });
 
 document.addEventListener('MezzuriteNotFound', () => {
-  console.log('CS: Got an event: MezzuriteNotFound');
   sendSimpleMessage('mezzuriteNotFound');
 });
 
 document.addEventListener('MezzuriteTiming_toExtension', timingEvent => {
-  console.log('CS: Got a timing event!');
-  console.log(timingEvent);
   forwardTimingEvent(timingEvent);
 });
 

--- a/src/devtools/index.js
+++ b/src/devtools/index.js
@@ -11,7 +11,5 @@ function createPanel () {
   const title = 'Mezzurite';
   const iconPath = null;
   const pagePath = 'devpanel.html'; // Relative path is apparently determined from the manifest.json's position
-  chrome.devtools.panels.create(title, iconPath, pagePath, function (panel) {
-    console.log('DT: The Mezzurite panel in DevTools was created!');
-  });
+  chrome.devtools.panels.create(title, iconPath, pagePath);
 }

--- a/src/inject/index.js
+++ b/src/inject/index.js
@@ -26,7 +26,6 @@ function initTimingEventForwarding () {
     // No access to chrome dev tools or chrome APIs
     // Need to forward these messages via some DOM element
     // to the content script that injected this function in the first place.
-    console.log('IS: Mezzurite Timing event was detected! Forwarding to content script.');
     forwardTimingEvent(timingEvent);
   });
 }


### PR DESCRIPTION
The background script was excluded, because these `console.log` calls only log to the background page's console, so the user will not see them. They'd have to manually inspect the background page via the extension manager page to see them.

Further, given that some branches in BackgroundController.js only print things to the console as stubs for future functionality and that the class will be entirely refactored later, I'd like to leave those in.