### PR TITLE
Remove npm audit from pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,10 +22,6 @@ steps:
   displayName: 'Install npm dependencies'
 
 - script: |
-    npm audit
-  displayName: 'Auditing dependencies'
-
-- script: |
     npm run lint
   displayName: 'Linting code'
 


### PR DESCRIPTION
We can use github's automated security fix feature after this is merged.